### PR TITLE
add missing packages for node-gyp on ubuntu20.04 arm64

### DIFF
--- a/examples/install_with_clone.sh
+++ b/examples/install_with_clone.sh
@@ -26,7 +26,7 @@ fi
 
 
 # Install Dependecies
-apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl unzip zip git nodejs openssl || exit $?
+apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl unzip zip git nodejs gcc g++ make openssl || exit $?
 apt-get install -y mysql-server || apt-get install -y default-mysql-server || exit $?
 apt-get install -y --no-install-recommends cron || exit $?
 

--- a/examples/install_with_clone.sh
+++ b/examples/install_with_clone.sh
@@ -26,13 +26,18 @@ fi
 
 
 # Install Dependecies
-apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl unzip zip git nodejs gcc g++ make openssl || exit $?
+apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl unzip zip git nodejs openssl || exit $?
 apt-get install -y mysql-server || apt-get install -y default-mysql-server || exit $?
 apt-get install -y --no-install-recommends cron || exit $?
 
 if [ "$os_distribution" == "bullseye" ]
 then
     apt-get install -y npm || exit $?
+fi
+
+if [ "$(uname -m)" == "aarch64" ]
+then
+    apt-get install -y gcc g++ make || exit $?
 fi
 
 npm -g install pm2 || exit $?


### PR DESCRIPTION
when i install LxdMosaic using lxd on raspberrypy(ubuntu server), there is missing packages for node-gpy
so i added `gcc` `g++` `make`