### PR TITLE
Support subscribing to different project operations socket

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,11 +3,12 @@ Unreleased
 Changed
     Image shown as part of instance details instead of title
     Allow setting memory limit when creating a VM (#330)
+    Support subscribing to different project operations socket (#332)
 
 Fixed
     Storage progress bar calculation is incorrect (#333)
     An error gathering fleet storage usasge data
-     memory stats are used in the storage part of the widget (#332) 
+     memory stats are used in the storage part of the widget (#332)
 
 0.11.0 - 29/12/2020 (Happy 2 year birthday LXDMosaic)
 

--- a/node/events.js
+++ b/node/events.js
@@ -100,12 +100,6 @@ var httpsServer = https.createServer(
 
 expressWs(app, httpsServer)
 
-function createWebSockets() {
-  hosts.loadHosts().then(hostDetails => {
-    hostOperations.setupWebsockets(hostDetails);
-  });
-}
-
 //NOT authenticated because its not interesting but access may be required
 app.get('/', function(req, res) {
   res.sendFile(path.join(__dirname + '/index.html'));
@@ -120,12 +114,8 @@ app.post('/terminals', function(req, res) {
   res.send();
 });
 
-//NOT authenticated because its called by php
+//TODO Remove whole thing from php
 app.get('/hosts/reload/', function(req, res) {
-  createWebSockets();
-  res.send({
-    success: 'reloaded',
-  });
 });
 
 //NOT authenticated because its called by php
@@ -191,7 +181,10 @@ app.ws('/node/terminal/', (socket, req) => {
 })
 
 app.ws('/node/operations', (socket, req) => {
-    hostOperations.addClientSocket(socket)
+    let host = req.query.hostId,
+        userId = req.query.userId,
+        project = req.query.project;
+    hostOperations.addClientSocket(socket, userId, host, project)
 })
 
 app.ws('/node/console', (socket, req) => {
@@ -251,14 +244,12 @@ if(!usingSqllite){
 hosts = new Hosts(con, fs, rp);
 allowedProjects = new AllowedProjects(con);
 wsTokens = new WsTokens(con);
-hostOperations = new HostOperations(fs);
+hostOperations = new HostOperations(hosts);
 terminals = new Terminals(rp);
 vgaTerminals = new VgaTerminals(rp, hosts);
 
-
 httpsServer.listen(3000, function() {});
 
-createWebSockets();
 process.on('SIGINT', function() {
   hostOperations.closeSockets();
   terminals.closeAll();

--- a/node/events.js
+++ b/node/events.js
@@ -114,10 +114,6 @@ app.post('/terminals', function(req, res) {
   res.send();
 });
 
-//TODO Remove whole thing from php
-app.get('/hosts/reload/', function(req, res) {
-});
-
 //NOT authenticated because its called by php
 app.post('/hosts/message/', function(req, res) {
   hostOperations.sendToOpsClients(req.body.type, req.body.data);

--- a/src/assets/lxdMosaic/operationSockets.js
+++ b/src/assets/lxdMosaic/operationSockets.js
@@ -1,0 +1,106 @@
+var currentSockets = {};
+
+function openHostOperationSocket(hostId, project)
+{
+    if(currentSockets.hasOwnProperty(hostId) && currentSockets[hostId].hasOwnProperty(project)){
+        console.log("already got");
+        return true;
+    }else if(currentSockets.hasOwnProperty(hostId) && !currentSockets[hostId].hasOwnProperty(project) && Object.keys(currentSockets[hostId]).length > 0){
+        Object.keys(currentSockets[hostId]).forEach((project)=>{
+            currentSockets[hostId][project].close()
+        });
+    }
+
+    let operationSocket = new WebSocket(`wss://${getQueryVar("host", window.location.hostname)}:${getQueryVar("port", 443)}/node/operations?ws_token=${userDetails.apiToken}&user_id=${userDetails.userId}&hostId=${hostId}&project=${project}`);
+
+    operationSocket.onclose = (msg) => {
+        delete currentSockets[hostId][project]
+    }
+
+    operationSocket.onmessage = (msg) => {
+        msg = JSON.parse(msg.data);
+
+        if(msg.mosaicType == "hostChange"){
+            let data = $.parseJSON(msg);
+            let status = data.offline ? "offline" : "online";
+            makeServerChangePopup(status, data.host);
+        }else if(msg.mosaicType == "deploymentProgress"){
+            let tr = $("#deploymentContainersList").find("tr[data-deployment-container='" + msg.hostname + "']");
+            if(tr.length > 0){
+                $(tr).find("td:eq(5)").html(`<i class='fas fa-check'></i> ${moment().fromNow()}`);
+            }
+        }else if(msg.mosaicType == "operationUpdate"){
+            let id = msg.metadata.id;
+            let icon = statusCodeIconMap[msg.metadata.status_code];
+            let description = msg.metadata.hasOwnProperty("description") ? msg.metadata.description : "No Description Available";
+            let host = msg.host;
+            let hostList = $("#operationsList").find(`[data-host='${host}']`);
+
+            let loadServerOviewDescriptions = [
+                "Transferring snapshot",
+                "Creating container"
+            ]
+
+            if(loadServerOviewDescriptions.includes(msg.metadata.description)  && msg.metadata.status_code == 200 && $("#mainBreadcrumb").find(".active").text()){
+                if($(`.nav-item[data-hostid='${msg.hostId}']`).hasClass("open")){
+                    loadContainerTreeAfter(0, msg.hostId, msg.hostAlias);
+                }
+            }
+
+            if(hostList.length == 0){
+                $("#operationsList").append(`<div data-host='${host}' class="mt-2">
+                <div class='text-center'>
+                <h5><u>
+                ${msg.hostAlias}
+                </u></h5>
+                </div>
+                <div class='opList'></div></div>`
+            );
+            }
+
+            let hostOpList = hostList.find(".opList");
+
+            let liItem = hostOpList.find(`#${id}`);
+
+            if(hostOpList.find("div").length >= 10){
+                hostOpList.find("div").last().remove();
+            }
+
+            if(liItem.length > 0){
+                // Some sort of race condition exists with the closing of a terminal
+                // that emits a 103 / 105 status code after the 200 code so it causes
+                // the operation list to say running even though the socket has closed
+                // so this is a work around as im pretty once an event goes to 200 that
+                // is it finished
+                let span = liItem.find("span:eq(0)");
+                if(span.data("status") == 200){
+                    return;
+                }
+
+                liItem.html(`<span data-status='${msg.metadata.status_code}' class='${icon} mr-2'></span>${description}`);
+
+                if(msg.metadata !== null && msg.metadata.hasOwnProperty("metadata") && msg.metadata.metadata !== null && msg.metadata.metadata.hasOwnProperty("download_progress")){
+                    let progress = msg.metadata.metadata["download_progress"].replace("rootfs: ", "");
+                    liItem.html(`<span data-status='${msg.metadata.status_code}' class='${icon} mr-2'></span>${description} - ${progress}`);
+                }
+
+                if(msg.metadata.err !== ""){
+                    $(liItem).data({
+                        toggle: "tooltip",
+                        placement: "bottom",
+                        title: msg.metadata.err
+                    }).addClass("btn-link text-danger").tooltip();
+                }
+
+            }else{
+                hostOpList.prepend(makeOperationHtmlItem(id, icon, description, msg.metadata.status_code));
+            }
+        }
+    }
+
+    if(!currentSockets.hasOwnProperty(hostId)){
+        currentSockets[hostId] = {};
+    }
+
+    currentSockets[hostId][project] = operationSocket;
+}

--- a/src/classes/App/ExceptionHandler.php
+++ b/src/classes/App/ExceptionHandler.php
@@ -4,7 +4,6 @@ namespace dhope0000\LXDClient\App;
 use dhope0000\LXDClient\Tools\Utilities\StringTools;
 use dhope0000\LXDClient\Model\Hosts\GetDetails;
 use dhope0000\LXDClient\Model\Hosts\ChangeStatus;
-use dhope0000\LXDClient\Tools\Node\Hosts;
 
 class ExceptionHandler
 {
@@ -13,11 +12,10 @@ class ExceptionHandler
     /**
      * @Inject
      */
-    public function inject(GetDetails $getDetails, ChangeStatus $changeStatus, Hosts $hosts)
+    public function inject(GetDetails $getDetails, ChangeStatus $changeStatus)
     {
         $this->getDetails = $getDetails;
         $this->changeStatus = $changeStatus;
-        $this->hosts = $hosts;
     }
 
     public function register()
@@ -39,7 +37,6 @@ class ExceptionHandler
             if (is_numeric($hostId)) {
                 http_response_code(205);
                 $this->changeStatus->setOffline($hostId);
-                $this->hosts->reloadHosts();
             }
         }
 

--- a/src/classes/Tools/Hosts/AddHosts.php
+++ b/src/classes/Tools/Hosts/AddHosts.php
@@ -5,7 +5,6 @@ namespace dhope0000\LXDClient\Tools\Hosts;
 use dhope0000\LXDClient\Model\Hosts\AddHost as AddHostModel;
 use dhope0000\LXDClient\Tools\Hosts\GenerateCert;
 use dhope0000\LXDClient\Model\Hosts\GetDetails;
-use dhope0000\LXDClient\Tools\Node\Hosts;
 use dhope0000\LXDClient\Model\Client\LxdClient;
 use dhope0000\LXDClient\Model\Users\FetchUserDetails;
 
@@ -15,14 +14,12 @@ class AddHosts
         AddHostModel $addHost,
         GenerateCert $generateCert,
         GetDetails $getDetails,
-        Hosts $hosts,
         LxdClient $lxdClient,
         FetchUserDetails $fetchUserDetails
     ) {
         $this->generateCert = $generateCert;
         $this->addHost = $addHost;
         $this->getDetails = $getDetails;
-        $this->hosts = $hosts;
         $this->lxdClient = $lxdClient;
         $this->fetchUserDetails = $fetchUserDetails;
     }
@@ -96,8 +93,6 @@ class AddHosts
                 throw new \Exception("Can't connect to ". $hostsDetail['name'] . ", is lxd running and the port open?", 1);
             }
         }
-
-        $this->hosts->reloadHosts();
 
         return true;
     }

--- a/src/classes/Tools/Node/Hosts.php
+++ b/src/classes/Tools/Node/Hosts.php
@@ -4,24 +4,6 @@ namespace dhope0000\LXDClient\Tools\Node;
 
 class Hosts
 {
-    public function reloadHosts()
-    {
-        // Get cURL resource
-        $curl = curl_init();
-        // Set some options - we are passing in a useragent too here
-        curl_setopt_array($curl, array(
-            CURLOPT_RETURNTRANSFER => 1,
-            CURLOPT_URL => 'https://localhost:3000/hosts/reload',
-            CURLOPT_USERAGENT => 'Codular Sample cURL Request',
-            CURLOPT_SSL_VERIFYHOST => 0,
-            CURLOPT_SSL_VERIFYPEER => 0,
-        ));
-        // Send the request & save response to $resp
-        $resp = curl_exec($curl);
-        // Close request to clear up some resources
-        curl_close($curl);
-    }
-
     public function sendMessage(string $type, array $data)
     {
         $ch = curl_init();

--- a/src/cronJobs/scripts/hostsOnline.php
+++ b/src/cronJobs/scripts/hostsOnline.php
@@ -24,7 +24,6 @@ function disableHost($hostId, $urlAndPort, $sendMessageAndReload = true, $change
     $changeStatus->setOffline($hostId);
     if ($sendMessageAndReload) {
         $reloadNode->sendMessage("hostChange", ["host"=>$urlAndPort,"offline"=>true]);
-        $reloadNode->reloadHosts();
     }
 }
 
@@ -40,7 +39,6 @@ foreach ($allHosts as $host) {
 
         if ($host["Host_Online"] != true) {
             $reloadNode->sendMessage("hostChange", ["host"=>$host["Host_Url_And_Port"],"offline"=>false]);
-            $reloadNode->reloadHosts();
         }
     } catch (\Http\Client\Exception\NetworkException $e) {
         disableHost($host["Host_ID"], $host["Host_Url_And_Port"], $host["Host_Online"] == true, $changeStatus, $reloadNode);
@@ -50,7 +48,5 @@ foreach ($allHosts as $host) {
         // "failed to begin transaction: call exec-sql (budget 0s): receive: header: EOF"
         // which is pretty useful i guess to log
         disableHost($host["Host_ID"], $host["Host_Url_And_Port"], $host["Host_Online"] == true, $changeStatus, $reloadNode);
-    } finally {
-        $reloadNode->reloadHosts();
     }
 }

--- a/src/views/index.php
+++ b/src/views/index.php
@@ -75,6 +75,7 @@ if ($haveServers->haveAny() !== true) {
 
       <script src="/assets/lxdMosaic/globalFunctions.js"></script>
       <script src="/assets/lxdMosaic/globalDetails.js"></script>
+      <script src="/assets/lxdMosaic/operationSockets.js"></script>
       <script>
           var currentContainerDetails = null;
 
@@ -539,90 +540,8 @@ $("#sidebar-ul").on("click", ".nav-item", function(){
 
     $("#sidebar-ul").find(".text-info").removeClass("text-info");
     $(this).find(".nav-link").addClass("text-info");
-})
+});
 
-let operationSocket = new WebSocket(`wss://${getQueryVar("host", window.location.hostname)}:${getQueryVar("port", 443)}/node/operations?ws_token=${userDetails.apiToken}&user_id=${userDetails.userId}`)
-
-operationSocket.onmessage = (msg) => {
-    msg = JSON.parse(msg.data);
-
-    if(msg.mosaicType == "hostChange"){
-        let data = $.parseJSON(msg);
-        let status = data.offline ? "offline" : "online";
-        makeServerChangePopup(status, data.host);
-    }else if(msg.mosaicType == "deploymentProgress"){
-        let tr = $("#deploymentContainersList").find("tr[data-deployment-container='" + msg.hostname + "']");
-        if(tr.length > 0){
-            $(tr).find("td:eq(5)").html(`<i class='fas fa-check'></i> ${moment().fromNow()}`);
-        }
-    }else if(msg.mosaicType == "operationUpdate"){
-        let id = msg.metadata.id;
-        let icon = statusCodeIconMap[msg.metadata.status_code];
-        let description = msg.metadata.hasOwnProperty("description") ? msg.metadata.description : "No Description Available";
-        let host = msg.host;
-        let hostList = $("#operationsList").find(`[data-host='${host}']`);
-
-        let loadServerOviewDescriptions = [
-            "Transferring snapshot",
-            "Creating container"
-        ]
-
-        if(loadServerOviewDescriptions.includes(msg.metadata.description)  && msg.metadata.status_code == 200 && $("#mainBreadcrumb").find(".active").text()){
-            if($(`.nav-item[data-hostid='${msg.hostId}']`).hasClass("open")){
-                loadContainerTreeAfter(0, msg.hostId, msg.hostAlias);
-            }
-        }
-
-        if(hostList.length == 0){
-            $("#operationsList").append(`<div data-host='${host}' class="mt-2">
-            <div class='text-center'>
-            <h5><u>
-            ${msg.hostAlias}
-            </u></h5>
-            </div>
-            <div class='opList'></div></div>`
-        );
-        }
-
-        let hostOpList = hostList.find(".opList");
-
-        let liItem = hostOpList.find(`#${id}`);
-
-        if(hostOpList.find("div").length >= 10){
-            hostOpList.find("div").last().remove();
-        }
-
-        if(liItem.length > 0){
-            // Some sort of race condition exists with the closing of a terminal
-            // that emits a 103 / 105 status code after the 200 code so it causes
-            // the operation list to say running even though the socket has closed
-            // so this is a work around as im pretty once an event goes to 200 that
-            // is it finished
-            let span = liItem.find("span:eq(0)");
-            if(span.data("status") == 200){
-                return;
-            }
-
-            liItem.html(`<span data-status='${msg.metadata.status_code}' class='${icon} mr-2'></span>${description}`);
-
-            if(msg.metadata !== null && msg.metadata.hasOwnProperty("metadata") && msg.metadata.metadata !== null && msg.metadata.metadata.hasOwnProperty("download_progress")){
-                let progress = msg.metadata.metadata["download_progress"].replace("rootfs: ", "");
-                liItem.html(`<span data-status='${msg.metadata.status_code}' class='${icon} mr-2'></span>${description} - ${progress}`);
-            }
-
-            if(msg.metadata.err !== ""){
-                $(liItem).data({
-                    toggle: "tooltip",
-                    placement: "bottom",
-                    title: msg.metadata.err
-                }).addClass("btn-link text-danger").tooltip();
-            }
-
-        }else{
-            hostOpList.prepend(makeOperationHtmlItem(id, icon, description, msg.metadata.status_code));
-        }
-    }
-}
 
 $(".sidebar-nav").on("click", ".nav-item", function(){
     if(consoleSocket !== undefined && currentTerminalProcessId !== null){
@@ -1098,8 +1017,10 @@ function loadDashboard(){
                 });
                 projects += "</select>";
             }
+
             if(host.hostOnline == true){
                 hostsTrs += `<tr data-host-id="${host.hostId}"><td><a data-id="${host.hostId}" class="viewHost" href="#">${host.alias}</a></td><td>${projects}</td></tr>`
+                openHostOperationSocket(host.hostId, host.currentProject);
             }
 
             hosts += `<li data-hostId="${host.hostId}" data-alias="${host.alias}" class="nav-item containerList nav-dropdown">
@@ -1296,6 +1217,7 @@ $(document).on("change", ".changeHostProject", function(){
     ajaxRequest(globalUrls.user.setHostProject, x, function(data){
         makeToastr(data);
         addHostContainerList(x.hostId, selected.data("alias"));
+        openHostOperationSocket(x.hostId, selected.val());
     })
 
 });


### PR DESCRIPTION
When a user switches project / isn't part of the default project they need to be able to access "operations" (I.E "instance start", "instance stop") from different projects

closes #322