### PR TITLE
Fix removing Host from HostCollection causing timeouts

### DIFF
--- a/src/classes/Objects/HostsCollection.php
+++ b/src/classes/Objects/HostsCollection.php
@@ -28,7 +28,7 @@ class HostsCollection implements \Iterator, \JsonSerializable
 
     public function removeHostId(int $hostId)
     {
-        foreach ($this as $index => $host) {
+        foreach ($this->hosts as $index => $host) {
             if ($host->getHostId() == $hostId) {
                 unset($this->hosts[$index]);
                 break;


### PR DESCRIPTION
PHP doesn't appear to like when you use $this to start iterating
an object from within iteslf and then deleting an element.
So instead we directly loop over the private array from within the class
and remove the element that way, might be a bug in PHP might be bad code

A quick google search doesn't yeild many anwsers so just going to move
on as this appears to fix it!

close #388 