### PR TITLE
Use date ranges instead of created dates for project analytics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Changed
     Only allow choosing one host when deploying cloud-config (only on frontend)
     Add cloud & desktop icons to image lists to indicate different variants
     Improve search remote image server result layout
+    Use date ranges instead of created dates for project analytics
 
 Fixed
     First run doesn't toggle passwords properly (#390)

--- a/src/classes/Tools/ProjectAnalytics/GetGraphableProjectAnalytics.php
+++ b/src/classes/Tools/ProjectAnalytics/GetGraphableProjectAnalytics.php
@@ -5,33 +5,99 @@ namespace dhope0000\LXDClient\Tools\ProjectAnalytics;
 use dhope0000\LXDClient\Model\ProjectAnalytics\FetchAnalytics;
 use dhope0000\LXDClient\Model\Users\FetchUserDetails;
 use dhope0000\LXDClient\Model\Users\AllowedProjects\FetchAllowedProjects;
+use dhope0000\LXDClient\Tools\Utilities\DateTools;
 
 class GetGraphableProjectAnalytics
 {
     private $fetchAnalytics;
     private $fetchUserDetails;
     private $fetchAllowedProjects;
+    private $dateTools;
 
     public function __construct(
         FetchAnalytics $fetchAnalytics,
         FetchUserDetails $fetchUserDetails,
-        FetchAllowedProjects $fetchAllowedProjects
+        FetchAllowedProjects $fetchAllowedProjects,
+        DateTools $dateTools
     ) {
         $this->fetchAnalytics = $fetchAnalytics;
         $this->fetchUserDetails = $fetchUserDetails;
         $this->fetchAllowedProjects = $fetchAllowedProjects;
+        $this->dateTools = $dateTools;
     }
 
     public function getCurrent(int $userId, string $history = "-30 minutes")
     {
         $startDate = (new \DateTime())->modify($history);
         $endDate = (new \DateTime());
+        $rangeTemplate = $this->getDateInternval($startDate, $endDate);
+        // Reconstruct the first date to account for rounding done when
+        // setting up the range template
+        $startDate = new \DateTimeImmutable(array_keys($rangeTemplate)[0]);
 
         $enteries = $this->fetchAnalytics->fetchBetween($startDate, $endDate);
-        return $this->groupEnteries($userId, $enteries);
+        return $this->groupEnteries($userId, $enteries, $rangeTemplate);
     }
 
-    private function groupEnteries(int $userId, array $entries)
+    private function getDateInternval($start, $end)
+    {
+        $period = new \DatePeriod(
+            $start,
+            new \DateInterval('P1D'),
+            $end->setTime(23, 59)
+        );
+
+        $numberOfDays = (int) ($period->getStartDate())->diff($period->getEndDate())->format("%R%a");
+        $numberOfMinutes = (int) ($period->getStartDate())->diff($period->getEndDate())->i;
+        $numberOfHours = (int) ($period->getStartDate())->diff($period->getEndDate())->h;
+
+        $step = 5;
+        if ($numberOfDays == 0 && $numberOfHours >= 3) {
+            $step = 15;
+        } elseif ($numberOfDays == 0 && $numberOfHours >= 6) {
+            $step = 30;
+        }
+
+        $dataByDate = [];
+
+        foreach ($period as $key => $value) {
+            $dateString = $value->format("Y-m-d");
+
+            if ($numberOfDays >= 1 && $numberOfHours > 12) {
+                if ($numberOfDays <= 7) {
+                    $dataByDate[$dateString . " " . "08:00"] = null;
+                    $dataByDate[$dateString . " " . "12:00"] = null;
+                    $dataByDate[$dateString . " " . "18:00"] = null;
+                } else {
+                    $dataByDate[$dateString. " " . "12:00"] = null;
+                }
+                continue;
+            }
+
+            $startMinute = 0;
+            $startHour = 0;
+            $stopAtNow = $dateString === $period->getEndDate()->format("Y-m-d");
+
+            // If this day is the start date
+            if ($period->getStartDate()->format("Y-m-d") === $dateString) {
+                $startHour = $period->getStartDate()->format("H");
+
+                $startMinute = $period->getStartDate()->format("i");
+
+                // round down to the nearest point
+                $startMinute = floor($startMinute / $step) * $step;
+            }
+
+            $points = DateTools::hoursRange($startHour, 24, $step, "", $stopAtNow, $startMinute);
+
+            foreach ($points as $time=>$value) {
+                $dataByDate[$dateString . " " . $time] = $value;
+            }
+        }
+        return $dataByDate;
+    }
+
+    private function groupEnteries(int $userId, array $entries, $rangeTemplate)
     {
         $isAdmin = (bool) $this->fetchUserDetails->isAdmin($userId);
         $allowedProjects = $this->fetchAllowedProjects->fetchAll($userId);
@@ -62,20 +128,23 @@ class GetGraphableProjectAnalytics
             }
 
             if (!isset($output[$alias][$project][$type])) {
-                $output[$alias][$project][$type] = [];
+                $output[$alias][$project][$type] = $rangeTemplate;
             }
 
             if (!isset($typeTotals[$type])) {
-                $typeTotals[$type] = [];
+                $typeTotals[$type] = $rangeTemplate;
             }
 
-            if (!isset($typeTotals[$type][$entry["created"]])) {
-                $typeTotals[$type][$entry["created"]] = 0;
+            $created = (new \DateTime($entry["created"]))->format("Y-m-d H:i");
+            // Slower than isset() but because the values are null isset()
+            // cant be used
+            if (!array_key_exists($created, $typeTotals[$type])) {
+                continue;
             }
 
-            $typeTotals[$type][$entry["created"]] += $entry["value"];
+            $typeTotals[$type][$created] += $entry["value"];
 
-            $output[$alias][$project][$type][] = [
+            $output[$alias][$project][$type][$created] = [
                 "created"=>$entry["created"],
                 "value"=>$entry["value"],
                 "limit"=>$entry["limit"]

--- a/src/views/boxes/boxComponents/dashboard/generalDashboard.html
+++ b/src/views/boxes/boxComponents/dashboard/generalDashboard.html
@@ -77,9 +77,7 @@
             let entries = totals[title];
             let noOfEntries = Object.keys(entries).length;
 
-            // There is a snapshot every 5 minutes and there are 12 5 minute chucks in an hour
-            // so 12 chuncks * 24 hours = 288 entries for 1 day
-            let dateFormat = noOfEntries >= 288 ? "ll HH:mm" : "HH:mm"
+            let dateFormat = noOfEntries == 13 || noOfEntries == 7 ? "HH:mm" : "ll HH:mm"
 
             $.each(entries, (created, value) => {
                 labels.push(moment.utc(created).local().format(dateFormat))
@@ -87,6 +85,8 @@
             });
 
             var totalUsage = values.reduce(function(a, b) {
+                a = a == null ? 0 : a
+                b = b == null ? 0 : b
                 return parseInt(a) + parseInt(b);
             }, 0);
 
@@ -120,7 +120,7 @@
                     elements: {
                         point: {
                             // After 6 hours hide the dots on the graph
-                            radius: noOfEntries >= 72 ? 0 : 3
+                            radius: 0
                         }
                     }
                 };
@@ -151,15 +151,6 @@
                     gridLines: {
                         color: "rgba(0, 0, 0, 0)",
                     },
-                    ticks: {
-                        callback: function(label) {
-                            if (noOfEntries >= 288) {
-                                return label;
-                            } else {
-                                return ''
-                            }
-                        }
-                    }
                 }]
 
                 new Chart(x.find("#" + cId), {

--- a/src/views/boxes/boxComponents/dashboard/projectAnalytics.html
+++ b/src/views/boxes/boxComponents/dashboard/projectAnalytics.html
@@ -88,17 +88,23 @@
                     let entries = projectAnalytics[alias][project][title];
                     let noOfEntries = Object.keys(entries).length;
 
-                    // There is a snapshot every 5 minutes and there are 12 5 minute chucks in an hour
-                    // so 12 chuncks * 24 hours = 288 entries for 1 day
-                    let dateFormat = noOfEntries >= 288 ? "ll HH:mm" : "HH:mm"
+                    let dateFormat = noOfEntries == 13 || noOfEntries == 7 ? "HH:mm" : "ll HH:mm"
 
-                    $.each(entries, (_, entry) => {
-                        labels.push(moment.utc(entry.created).local().format(dateFormat))
-                        values.push(entry.value)
-                        limits.push(entry.limit)
+                    $.each(entries, (dateTime, entry) => {
+                        if (entry == null) {
+                            labels.push(moment.utc(dateTime).local().format(dateFormat))
+                            values.push(null)
+                            limits.push(null)
+                        } else {
+                            labels.push(moment.utc(entry.created).local().format(dateFormat))
+                            values.push(entry.value)
+                            limits.push(entry.limit)
+                        }
                     });
 
                     var totalUsage = values.reduce(function(a, b) {
+                        a = a == null ? 0 : a
+                        b = b == null ? 0 : b
                         return parseInt(a) + parseInt(b);
                     }, 0);
 
@@ -147,7 +153,7 @@
                             elements: {
                                 point: {
                                     // After 6 hours hide the dots on the graph
-                                    radius: noOfEntries >= 72 ? 0 : 3
+                                    radius: 0
                                 }
                             }
                         };
@@ -170,15 +176,6 @@
                             gridLines: {
                                 color: "rgba(0, 0, 0, 0)",
                             },
-                            ticks: {
-                                callback: function(label) {
-                                    if (noOfEntries >= 288) {
-                                        return label;
-                                    } else {
-                                        return ''
-                                    }
-                                }
-                            }
                         }]
 
                         new Chart(projectMetricGraphCol.find("#" + cId), {


### PR DESCRIPTION
This makes sure when data isn't available the graphs show an empty
spot instead of "bunching up" the data to make it look like one line.