### PR TITLE
Debian requires the ssl-cert package to create the snakeoil certificates

### DIFF
--- a/examples/install_with_clone.sh
+++ b/examples/install_with_clone.sh
@@ -26,7 +26,7 @@ fi
 
 
 # Install Dependecies
-apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl php-ldap php-mbstring unzip zip git nodejs openssl || exit $?
+apt-get install -y apache2 php php-cli php-json php-mysql php-xml php-curl php-ldap php-mbstring unzip zip git nodejs openssl ssl-cert || exit $?
 apt-get install -y mysql-server || apt-get install -y default-mysql-server || exit $?
 apt-get install -y --no-install-recommends cron || exit $?
 


### PR DESCRIPTION
As per request in #470