### PR TITLE
Deployments project restrictions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ Changed
     Remove profile name from deploy cloud-config as its no longer used
     Disable some spice channels to improve VM Terminal experience (#463)
     Open terminal when opening an instance view
+    Restrict deployments by user project access (Admin can access all) (#466)
 
 Fixed
     First run doesn't toggle passwords properly (#390)

--- a/db/migrations/20220303232930_deployments_projects.php
+++ b/db/migrations/20220303232930_deployments_projects.php
@@ -35,19 +35,25 @@ final class DeploymentsProjects extends AbstractMigration
             ->create();
 
         if ($this->isMigratingUp()) {
-            $this->execute("INSERT INTO `Deployment_Projects`(
-                `DP_User_ID`,
-                `DP_Deployment_ID`,
-                `DP_Host_ID`,
-                `DP_Project`
-            ) SELECT
-                (SELECT `User_ID` FROM `Users` WHERE `User_Admin` = 1 ORDER BY `User_Date_Created` ASC LIMIT 1),
-                `Deployment_ID`,
-                (SELECT `Host_ID` FROM `Hosts` ORDER BY `Host_ID` ASC LIMIT 1),
-                'default'
-            FROM
-                `Deployments`
-            ");
+            $builder = $this->getQueryBuilder();
+            $hosts = $builder->select('*')->from('Hosts')->execute()->fetchAll();
+            $builder = $this->getQueryBuilder();
+            $users = $builder->select('*')->from('Users')->execute()->fetchAll();
+            if (count($hosts) > 0 && count($users) > 0) {
+                $this->execute("INSERT INTO `Deployment_Projects`(
+                    `DP_User_ID`,
+                    `DP_Deployment_ID`,
+                    `DP_Host_ID`,
+                    `DP_Project`
+                ) SELECT
+                    (SELECT `User_ID` FROM `Users` WHERE `User_Admin` = 1 ORDER BY `User_Date_Created` ASC LIMIT 1),
+                    `Deployment_ID`,
+                    (SELECT `Host_ID` FROM `Hosts` ORDER BY `Host_ID` ASC LIMIT 1),
+                    'default'
+                FROM
+                    `Deployments`
+                ");
+            }
         }
     }
 }

--- a/db/migrations/20220303232930_deployments_projects.php
+++ b/db/migrations/20220303232930_deployments_projects.php
@@ -27,6 +27,11 @@ final class DeploymentsProjects extends AbstractMigration
             ->addForeignKey('DP_User_ID', 'Users', 'User_ID', ['delete'=> 'RESTRICT', 'update'=> 'RESTRICT'])
             ->addForeignKey('DP_Deployment_ID', 'Deployments', 'Deployment_ID', ['delete'=> 'CASCADE', 'update'=> 'RESTRICT'])
             ->addForeignKey('DP_Host_ID', 'Hosts', 'Host_ID', ['delete'=> 'CASCADE', 'update'=> 'RESTRICT'])
+            ->addIndex([
+                'DP_Deployment_ID',
+                'DP_Host_ID',
+                'DP_Project'
+            ], ['unique' => true,  'name' => 'unique_deployment_project'])
             ->create();
 
         if ($this->isMigratingUp()) {

--- a/db/migrations/20220303232930_deployments_projects.php
+++ b/db/migrations/20220303232930_deployments_projects.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class DeploymentsProjects extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $table = $this->table('Deployment_Projects', ['id' => "DP_ID", 'primary_key' => ["DP_ID"]]);
+        $table->addColumn('DP_Date_Created', 'datetime', ['default' => 'CURRENT_TIMESTAMP'])
+            ->addColumn('DP_User_ID', 'integer')
+            ->addColumn('DP_Deployment_ID', 'integer')
+            ->addColumn('DP_Host_ID', 'integer')
+            ->addColumn('DP_Project', 'string')
+            ->addForeignKey('DP_User_ID', 'Users', 'User_ID', ['delete'=> 'RESTRICT', 'update'=> 'RESTRICT'])
+            ->addForeignKey('DP_Deployment_ID', 'Deployments', 'Deployment_ID', ['delete'=> 'CASCADE', 'update'=> 'RESTRICT'])
+            ->addForeignKey('DP_Host_ID', 'Hosts', 'Host_ID', ['delete'=> 'CASCADE', 'update'=> 'RESTRICT'])
+            ->create();
+
+        if ($this->isMigratingUp()) {
+            $this->execute("INSERT INTO `Deployment_Projects`(
+                `DP_User_ID`,
+                `DP_Deployment_ID`,
+                `DP_Host_ID`,
+                `DP_Project`
+            ) SELECT
+                (SELECT `User_ID` FROM `Users` WHERE `User_Admin` = 1 ORDER BY `User_Date_Created` ASC LIMIT 1),
+                `Deployment_ID`,
+                (SELECT `Host_ID` FROM `Hosts` ORDER BY `Host_ID` ASC LIMIT 1),
+                'default'
+            FROM
+                `Deployments`
+            ");
+        }
+    }
+}

--- a/src/classes/Controllers/Deployments/DeleteDeploymentController.php
+++ b/src/classes/Controllers/Deployments/DeleteDeploymentController.php
@@ -14,9 +14,9 @@ class DeleteDeploymentController implements \dhope0000\LXDClient\Interfaces\Reco
     /**
      * @Route("", name="Delete Deployment")
      */
-    public function delete(int $deploymentId)
+    public function delete(int $userId, int $deploymentId)
     {
-        $this->deleteDeployment->delete($deploymentId);
+        $this->deleteDeployment->delete($userId, $deploymentId);
         return ["state"=>"success", "message"=>"Deleted deployment"];
     }
 }

--- a/src/classes/Controllers/Deployments/DeployController.php
+++ b/src/classes/Controllers/Deployments/DeployController.php
@@ -14,9 +14,9 @@ class DeployController implements \dhope0000\LXDClient\Interfaces\RecordAction
     /**
      * @Route("", name="Deploy Deployment")
      */
-    public function deploy(int $deploymentId, array $instances)
+    public function deploy(int $userId, int $deploymentId, array $instances)
     {
-        $data = $this->deploy->deploy($deploymentId, $instances);
+        $data = $this->deploy->deploy($userId, $deploymentId, $instances);
         return ["state"=>"success", "message"=>"Deployment complete", "data"=>$data];
     }
 }

--- a/src/classes/Controllers/Deployments/GetCloudsConfigController.php
+++ b/src/classes/Controllers/Deployments/GetCloudsConfigController.php
@@ -11,8 +11,8 @@ class GetCloudsConfigController
         $this->getCloudConfigs = $getCloudConfigs;
     }
 
-    public function get(int $deploymentId)
+    public function get(int $userId, int $deploymentId)
     {
-        return $this->getCloudConfigs->getAll($deploymentId);
+        return $this->getCloudConfigs->getAll($userId, $deploymentId);
     }
 }

--- a/src/classes/Controllers/Deployments/GetController.php
+++ b/src/classes/Controllers/Deployments/GetController.php
@@ -11,8 +11,8 @@ class GetController
         $this->getDeployments = $getDeployments;
     }
 
-    public function getAll()
+    public function getAll(int $userId)
     {
-        return $this->getDeployments->getAll();
+        return $this->getDeployments->getAll($userId);
     }
 }

--- a/src/classes/Controllers/Deployments/GetDeploymentController.php
+++ b/src/classes/Controllers/Deployments/GetDeploymentController.php
@@ -11,8 +11,8 @@ class GetDeploymentController
         $this->getDeployment = $getDeployment;
     }
 
-    public function get(int $deploymentId)
+    public function get(int $userId, int $deploymentId)
     {
-        return $this->getDeployment->get($deploymentId);
+        return $this->getDeployment->get($userId, $deploymentId);
     }
 }

--- a/src/classes/Controllers/Deployments/Projects/GetDeploymentProjectsController.php
+++ b/src/classes/Controllers/Deployments/Projects/GetDeploymentProjectsController.php
@@ -2,22 +2,26 @@
 
 namespace dhope0000\LXDClient\Controllers\Deployments\Projects;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
 use Symfony\Component\Routing\Annotation\Route;
 
 class GetDeploymentProjectsController
 {
+    private $authoriseDeploymentAccess;
     private $fetchDeploymentProjects;
 
-    public function __construct(FetchDeploymentProjects $fetchDeploymentProjects)
+    public function __construct(AuthoriseDeploymentAccess $authoriseDeploymentAccess, FetchDeploymentProjects $fetchDeploymentProjects)
     {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->fetchDeploymentProjects = $fetchDeploymentProjects;
     }
     /**
      * @Route("", name="Get Deployment Projects")
      */
-    public function get(int $deploymentId)
+    public function get(int $userId, int $deploymentId)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         return $this->fetchDeploymentProjects->fetchAll($deploymentId);
     }
 }

--- a/src/classes/Controllers/Deployments/Projects/GetDeploymentProjectsController.php
+++ b/src/classes/Controllers/Deployments/Projects/GetDeploymentProjectsController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace dhope0000\LXDClient\Controllers\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
+use Symfony\Component\Routing\Annotation\Route;
+
+class GetDeploymentProjectsController
+{
+    private $fetchDeploymentProjects;
+
+    public function __construct(FetchDeploymentProjects $fetchDeploymentProjects)
+    {
+        $this->fetchDeploymentProjects = $fetchDeploymentProjects;
+    }
+    /**
+     * @Route("", name="Get Deployment Projects")
+     */
+    public function get(int $deploymentId)
+    {
+        return $this->fetchDeploymentProjects->fetchAll($deploymentId);
+    }
+}

--- a/src/classes/Controllers/Deployments/Projects/SetDeploymentProjectsController.php
+++ b/src/classes/Controllers/Deployments/Projects/SetDeploymentProjectsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace dhope0000\LXDClient\Controllers\Deployments\Projects;
+
+use dhope0000\LXDClient\Tools\Deployments\Projects\SetDeploymentProjects;
+use Symfony\Component\Routing\Annotation\Route;
+use \DI\Container;
+
+class SetDeploymentProjectsController
+{
+    private $setDeploymentProjects;
+    private $container;
+
+    public function __construct(SetDeploymentProjects $setDeploymentProjects, Container $container)
+    {
+        $this->setDeploymentProjects = $setDeploymentProjects;
+        $this->container = $container;
+    }
+    /**
+     * @Route("", name="Set Deployment Projects")
+     */
+    public function set(int $userId, int $deploymentId, array $newProjectsLayout)
+    {
+        $this->container->call(["dhope0000\LXDClient\Model\Database\Database", "beginTransaction"]);
+        $this->setDeploymentProjects->set($userId, $deploymentId, $newProjectsLayout);
+        $this->container->call(["dhope0000\LXDClient\Model\Database\Database", "commitTransaction"]);
+        return ["state"=>"success", "message"=>"Updated Projects"];
+    }
+}

--- a/src/classes/Controllers/Deployments/StartDeploymentController.php
+++ b/src/classes/Controllers/Deployments/StartDeploymentController.php
@@ -15,9 +15,9 @@ class StartDeploymentController implements \dhope0000\LXDClient\Interfaces\Recor
     /**
      * @Route("", name="Start Deployment")
      */
-    public function start(int $deploymentId)
+    public function start(int $userId, int $deploymentId)
     {
-        $this->changeDeploymentState->change($deploymentId, StateConstants::START);
+        $this->changeDeploymentState->change($userId, $deploymentId, StateConstants::START);
         return ["state"=>"success", "message"=>"Deployment started"];
     }
 }

--- a/src/classes/Controllers/Deployments/StopDeploymentController.php
+++ b/src/classes/Controllers/Deployments/StopDeploymentController.php
@@ -15,9 +15,9 @@ class StopDeploymentController implements \dhope0000\LXDClient\Interfaces\Record
     /**
      * @Route("", name="Stop Deployment")
      */
-    public function stop(int $deploymentId)
+    public function stop(int $userId, int $deploymentId)
     {
-        $this->changeDeploymentState->change($deploymentId, StateConstants::STOP);
+        $this->changeDeploymentState->change($userId, $deploymentId, StateConstants::STOP);
         return ["state"=>"success", "message"=>"Deployment started"];
     }
 }

--- a/src/classes/Model/Deployments/FetchDeployments.php
+++ b/src/classes/Model/Deployments/FetchDeployments.php
@@ -25,6 +25,33 @@ class FetchDeployments
         return $do->fetchAll(\PDO::FETCH_ASSOC);
     }
 
+    public function fetchUserHasAccessTo(int $userId)
+    {
+        $sql = "SELECT DISTINCT
+                    `Deployment_ID` as `id`,
+                    `Deployment_Name` as `name`
+                FROM
+                    `User_Allowed_Projects`
+                LEFT JOIN  `Deployment_Projects` ON
+                    `Deployment_Projects`.`DP_Host_ID` = `User_Allowed_Projects`.`UAP_Host_ID`
+                    AND
+                    `Deployment_Projects`.`DP_Project` = `User_Allowed_Projects`.`UAP_Project`
+                LEFT JOIN  `Deployments` ON
+                    `Deployments`.`Deployment_ID` = `Deployment_Projects`.`DP_Deployment_ID`
+                WHERE
+                    `User_Allowed_Projects`.`UAP_User_ID` = :userId
+                AND
+                    `Deployment_Projects`.`DP_Host_ID` IS NOT NULL
+                ORDER BY
+                    `Deployment_ID` DESC
+                ";
+        $do = $this->database->prepare($sql);
+        $do->execute([
+            ":userId"=>$userId
+        ]);
+        return $do->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
     public function fetch(int $deploymentId)
     {
         $sql = "SELECT

--- a/src/classes/Model/Deployments/Projects/DeleteDeploymentProject.php
+++ b/src/classes/Model/Deployments/Projects/DeleteDeploymentProject.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace dhope0000\LXDClient\Model\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Database\Database;
+
+class DeleteDeploymentProject
+{
+    private $database;
+
+    public function __construct(Database $database)
+    {
+        $this->database = $database->dbObject;
+    }
+
+    public function delete(int $deploymentProjectId) :bool
+    {
+        $sql = "DELETE FROM `Deployment_Projects` WHERE `DP_ID` = :deploymentProjectId";
+        $do = $this->database->prepare($sql);
+        $do->execute([
+            ":deploymentProjectId"=>$deploymentProjectId
+        ]);
+        return $do->rowCount() ? true : false;
+    }
+}

--- a/src/classes/Model/Deployments/Projects/FetchDeploymentProjects.php
+++ b/src/classes/Model/Deployments/Projects/FetchDeploymentProjects.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace dhope0000\LXDClient\Model\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Database\Database;
+
+class FetchDeploymentProjects
+{
+    private $database;
+
+    public function __construct(Database $database)
+    {
+        $this->database = $database->dbObject;
+    }
+
+    public function fetchAll(int $deploymentId) :array
+    {
+        $sql = "SELECT
+                    `DP_ID` as `id`,
+                    COALESCE(`Host_Alias`, `Host_Url_And_Port`) as `hostAlias`,
+                    `DP_Project` as `project`
+                FROM
+                    `Deployment_Projects`
+                LEFT JOIN `Hosts` ON
+                    `Hosts`.`Host_ID` = `DP_Host_ID`
+                WHERE
+                    `DP_Deployment_ID` = :deploymentId
+                ";
+        $do = $this->database->prepare($sql);
+        $do->execute([
+            ":deploymentId"=>$deploymentId
+        ]);
+        return $do->fetchAll(\PDO::FETCH_ASSOC);
+    }
+}

--- a/src/classes/Model/Deployments/Projects/FetchDeploymentProjects.php
+++ b/src/classes/Model/Deployments/Projects/FetchDeploymentProjects.php
@@ -18,6 +18,7 @@ class FetchDeploymentProjects
         $sql = "SELECT
                     `DP_ID` as `id`,
                     COALESCE(`Host_Alias`, `Host_Url_And_Port`) as `hostAlias`,
+                    `Host_ID` as `hostId`,
                     `DP_Project` as `project`
                 FROM
                     `Deployment_Projects`

--- a/src/classes/Model/Deployments/Projects/FetchDeploymentProjectsUsers.php
+++ b/src/classes/Model/Deployments/Projects/FetchDeploymentProjectsUsers.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace dhope0000\LXDClient\Model\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Database\Database;
+
+class FetchDeploymentProjectsUsers
+{
+    private $database;
+
+    public function __construct(Database $database)
+    {
+        $this->database = $database->dbObject;
+    }
+
+    public function userHasAccess(int $userId, int $deploymentId) :bool
+    {
+        $sql = "SELECT
+                    1
+                FROM
+                    `Users`
+                LEFT JOIN `User_Allowed_Projects` ON
+                    `User_Allowed_Projects`.`UAP_User_ID` = `User_ID`
+                LEFT JOIN `Deployment_Projects` ON
+                    `DP_Deployment_ID` = :deploymentId AND
+                    `DP_Host_ID` = `User_Allowed_Projects`.`UAP_Host_ID` AND
+                    `DP_Project` = `User_Allowed_Projects`.`UAP_Project`
+                WHERE
+                    `User_ID` = :userId
+                AND
+                    (
+                        `Deployment_Projects`.`DP_Project` IS NOT NULL
+                        OR
+                        `User_Admin` = 1
+                    )
+                ";
+        $do = $this->database->prepare($sql);
+        $do->execute([
+            ":deploymentId"=>$deploymentId,
+            ":userId"=>$userId
+        ]);
+        return $do->fetchColumn() ? true : false;
+    }
+}

--- a/src/classes/Model/Deployments/Projects/InsertDeploymentProject.php
+++ b/src/classes/Model/Deployments/Projects/InsertDeploymentProject.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace dhope0000\LXDClient\Model\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Database\Database;
+
+class InsertDeploymentProject
+{
+    private $database;
+
+    public function __construct(Database $database)
+    {
+        $this->database = $database->dbObject;
+    }
+
+    public function insert(int $userId, int $deploymentId, int $hostId, string $project) :bool
+    {
+        $sql = "INSERT INTO `Deployment_Projects` (
+                    `DP_User_ID`,
+                    `DP_Deployment_ID`,
+                    `DP_Host_ID`,
+                    `DP_Project`
+                ) VALUES (
+                    :userId,
+                    :deploymentId,
+                    :hostId,
+                    :project
+                );";
+        $do = $this->database->prepare($sql);
+        $do->execute([
+            ":userId"=>$userId,
+            ":deploymentId"=>$deploymentId,
+            ":hostId"=>$hostId,
+            ":project"=>$project
+        ]);
+        return $do->rowCount() ? true : false;
+    }
+}

--- a/src/classes/Tools/Deployments/Authorise/AuthoriseDeploymentAccess.php
+++ b/src/classes/Tools/Deployments/Authorise/AuthoriseDeploymentAccess.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace dhope0000\LXDClient\Tools\Deployments\Authorise;
+
+use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjectsUsers;
+
+class AuthoriseDeploymentAccess
+{
+    private $fetchDeploymentProjectsUsers;
+    
+    public function __construct(
+        FetchDeploymentProjectsUsers $fetchDeploymentProjectsUsers
+    ) {
+        $this->fetchDeploymentProjectsUsers = $fetchDeploymentProjectsUsers;
+    }
+
+    public function authorise(int $userId, int $deploymentId) :bool
+    {
+        $allowedAccess = $this->fetchDeploymentProjectsUsers->userHasAccess(
+            $userId,
+            $deploymentId
+        );
+
+        if ($allowedAccess === false) {
+            throw new \Exception("No access to deployment", 1);
+        }
+
+        return true;
+    }
+}

--- a/src/classes/Tools/Deployments/ChangeDeploymentState.php
+++ b/src/classes/Tools/Deployments/ChangeDeploymentState.php
@@ -2,6 +2,7 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Tools\Deployments\Profiles\HostHaveDeploymentProfiles;
 use dhope0000\LXDClient\Tools\Deployments\Containers\GetContainersInDeployment;
 use dhope0000\LXDClient\Constants\StateConstants;
@@ -10,17 +11,20 @@ use dhope0000\LXDClient\Tools\Deployments\Containers\SetStartTimes;
 class ChangeDeploymentState
 {
     public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
         HostHaveDeploymentProfiles $hostHaveDeploymentProfiles,
         GetContainersInDeployment $getContainersInDeployment,
         SetStartTimes $setStartTimes
     ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->hostHaveDeploymentProfiles = $hostHaveDeploymentProfiles;
         $this->getContainersInDeployment = $getContainersInDeployment;
         $this->setStartTimes = $setStartTimes;
     }
 
-    public function change(int $deploymentId, string $state)
+    public function change(int $userId, int $deploymentId, string $state)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         $profiles = $this->hostHaveDeploymentProfiles->getAllProfilesInDeployment($deploymentId);
 
         $containers = $this->getContainersInDeployment->getFromProfile($profiles);

--- a/src/classes/Tools/Deployments/DeleteDeployment.php
+++ b/src/classes/Tools/Deployments/DeleteDeployment.php
@@ -2,6 +2,7 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Tools\Deployments\Profiles\HostHaveDeploymentProfiles;
 use dhope0000\LXDClient\Tools\Deployments\Containers\GetContainersInDeployment;
 use dhope0000\LXDClient\Model\Deployments\RemoveDeployment;
@@ -9,17 +10,20 @@ use dhope0000\LXDClient\Model\Deployments\RemoveDeployment;
 class DeleteDeployment
 {
     public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
         HostHaveDeploymentProfiles $hostHaveDeploymentProfiles,
         GetContainersInDeployment $getContainersInDeployment,
         RemoveDeployment $removeDeployment
     ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->hostHaveDeploymentProfiles = $hostHaveDeploymentProfiles;
         $this->getContainersInDeployment = $getContainersInDeployment;
         $this->removeDeployment = $removeDeployment;
     }
 
-    public function delete(int $deploymentId)
+    public function delete(int $userId, int $deploymentId)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         $profiles = $this->hostHaveDeploymentProfiles->getAllProfilesInDeployment($deploymentId);
         $containers = $this->getContainersInDeployment->getFromProfile($profiles);
 

--- a/src/classes/Tools/Deployments/Deploy.php
+++ b/src/classes/Tools/Deployments/Deploy.php
@@ -2,6 +2,7 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Tools\CloudConfig\DeployToProfile;
 use dhope0000\LXDClient\Tools\Utilities\StringTools;
 use dhope0000\LXDClient\Tools\Deployments\Profiles\HostHaveDeploymentProfiles;
@@ -17,6 +18,7 @@ use dhope0000\LXDClient\Tools\Utilities\ValidateInstanceName;
 class Deploy
 {
     public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
         DeployToProfile $deployToProfile,
         HostHaveDeploymentProfiles $hostHaveDeploymentProfiles,
         CreateInstance $createInstance,
@@ -25,6 +27,7 @@ class Deploy
         StoreDeployedContainerNames $storeDeployedContainerNames,
         GetDetails $getDetails
     ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->deployToProfile = $deployToProfile;
         $this->hostHaveDeploymentProfiles = $hostHaveDeploymentProfiles;
         $this->createInstance = $createInstance;
@@ -34,8 +37,9 @@ class Deploy
         $this->getDetails = $getDetails;
     }
 
-    public function deploy(int $deploymentId, array $instances)
+    public function deploy(int $userId, int $deploymentId, array $instances)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         $this->validateInstances($instances);
 
         $revIds = array_column($instances, "revId");

--- a/src/classes/Tools/Deployments/GetCloudConfigs.php
+++ b/src/classes/Tools/Deployments/GetCloudConfigs.php
@@ -2,17 +2,22 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Model\Deployments\CloudConfig\FetchCloudConfigs;
 
 class GetCloudConfigs
 {
-    public function __construct(FetchCloudConfigs $fetchCloudConfigs)
-    {
+    public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
+        FetchCloudConfigs $fetchCloudConfigs
+    ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->fetchCloudConfigs = $fetchCloudConfigs;
     }
 
-    public function getAll(int $deploymentId)
+    public function getAll(int $userId, int $deploymentId)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         return $this->fetchCloudConfigs->getAll($deploymentId);
     }
 }

--- a/src/classes/Tools/Deployments/GetDeployment.php
+++ b/src/classes/Tools/Deployments/GetDeployment.php
@@ -7,6 +7,7 @@ use dhope0000\LXDClient\Tools\Deployments\Profiles\HostHaveDeploymentProfiles;
 use dhope0000\LXDClient\Tools\Deployments\Containers\GetContainersInDeployment;
 use dhope0000\LXDClient\Model\Deployments\FetchDeployments;
 use dhope0000\LXDClient\Tools\Deployments\Containers\GetContainersInformation;
+use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
 
 class GetDeployment
 {
@@ -15,13 +16,15 @@ class GetDeployment
         HostHaveDeploymentProfiles $hostHaveDeploymentProfiles,
         GetContainersInDeployment $getContainersInDeployment,
         FetchDeployments $fetchDeployments,
-        GetContainersInformation $getContainersInformation
+        GetContainersInformation $getContainersInformation,
+        FetchDeploymentProjects $fetchDeploymentProjects
     ) {
         $this->fetchCloudConfigs = $fetchCloudConfigs;
         $this->hostHaveDeploymentProfiles = $hostHaveDeploymentProfiles;
         $this->getContainersInDeployment = $getContainersInDeployment;
         $this->fetchDeployments = $fetchDeployments;
         $this->getContainersInformation = $getContainersInformation;
+        $this->fetchDeploymentProjects = $fetchDeploymentProjects;
     }
 
     public function get(int $deploymentId)
@@ -39,6 +42,7 @@ class GetDeployment
         $output["cloudConfigs"] = $this->fetchCloudConfigs->getAll($deploymentId);
         $output["profiles"] = $profiles;
         $output["containers"] = $hostWithContainers;
+        $output["projects"] = $this->fetchDeploymentProjects->fetchAll($deploymentId);
         return $output;
     }
 

--- a/src/classes/Tools/Deployments/GetDeployment.php
+++ b/src/classes/Tools/Deployments/GetDeployment.php
@@ -2,6 +2,7 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
 use dhope0000\LXDClient\Model\Deployments\CloudConfig\FetchCloudConfigs;
 use dhope0000\LXDClient\Tools\Deployments\Profiles\HostHaveDeploymentProfiles;
 use dhope0000\LXDClient\Tools\Deployments\Containers\GetContainersInDeployment;
@@ -12,6 +13,7 @@ use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
 class GetDeployment
 {
     public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
         FetchCloudConfigs $fetchCloudConfigs,
         HostHaveDeploymentProfiles $hostHaveDeploymentProfiles,
         GetContainersInDeployment $getContainersInDeployment,
@@ -19,6 +21,7 @@ class GetDeployment
         GetContainersInformation $getContainersInformation,
         FetchDeploymentProjects $fetchDeploymentProjects
     ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->fetchCloudConfigs = $fetchCloudConfigs;
         $this->hostHaveDeploymentProfiles = $hostHaveDeploymentProfiles;
         $this->getContainersInDeployment = $getContainersInDeployment;
@@ -27,8 +30,9 @@ class GetDeployment
         $this->fetchDeploymentProjects = $fetchDeploymentProjects;
     }
 
-    public function get(int $deploymentId)
+    public function get(int $userId, int $deploymentId)
     {
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
         $output = [];
 
         $profiles = $this->hostHaveDeploymentProfiles->getAllProfilesInDeployment($deploymentId);

--- a/src/classes/Tools/Deployments/GetDeployments.php
+++ b/src/classes/Tools/Deployments/GetDeployments.php
@@ -4,20 +4,30 @@ namespace dhope0000\LXDClient\Tools\Deployments;
 
 use dhope0000\LXDClient\Model\Deployments\FetchDeployments;
 use dhope0000\LXDClient\Tools\Deployments\GetDeployment;
+use dhope0000\LXDClient\Model\Users\FetchUserDetails;
 
 class GetDeployments
 {
     public function __construct(
         FetchDeployments $fetchDeployments,
-        GetDeployment $getDeployment
+        GetDeployment $getDeployment,
+        FetchUserDetails $fetchUserDetails
     ) {
         $this->fetchDeployments = $fetchDeployments;
         $this->getDeployment = $getDeployment;
+        $this->fetchUserDetails = $fetchUserDetails;
     }
 
-    public function getAll()
+    public function getAll(int $userId)
     {
-        $deploymentList = $this->fetchDeployments->fetchAll();
+        $deploymentList = [];
+
+        if ($this->fetchUserDetails->isAdmin($userId) !== "1") {
+            $deploymentList = $this->fetchDeployments->fetchUserHasAccessTo($userId);
+        } else {
+            $deploymentList = $this->fetchDeployments->fetchAll();
+        }
+
         return $this->addDetails($deploymentList);
     }
 

--- a/src/classes/Tools/Deployments/GetDeployments.php
+++ b/src/classes/Tools/Deployments/GetDeployments.php
@@ -28,13 +28,13 @@ class GetDeployments
             $deploymentList = $this->fetchDeployments->fetchAll();
         }
 
-        return $this->addDetails($deploymentList);
+        return $this->addDetails($userId, $deploymentList);
     }
 
-    private function addDetails($deploymentList)
+    private function addDetails($userId, $deploymentList)
     {
         foreach ($deploymentList as $index =>$deployment) {
-            $details = $this->getDeployment->get($deployment["id"]);
+            $details = $this->getDeployment->get($userId, $deployment["id"]);
             $containerDetails = $this->getContainerDetails($details["containers"]);
             $deploymentList[$index]["containerDetails"] = $containerDetails;
         }

--- a/src/classes/Tools/Deployments/Projects/SetDeploymentProjects.php
+++ b/src/classes/Tools/Deployments/Projects/SetDeploymentProjects.php
@@ -2,21 +2,26 @@
 
 namespace dhope0000\LXDClient\Tools\Deployments\Projects;
 
+use dhope0000\LXDClient\Tools\Deployments\Authorise\AuthoriseDeploymentAccess;
+
 use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
 use dhope0000\LXDClient\Model\Deployments\Projects\InsertDeploymentProject;
 use dhope0000\LXDClient\Model\Deployments\Projects\DeleteDeploymentProject;
 
 class SetDeploymentProjects
 {
+    private $authoriseDeploymentAccess;
     private $fetchDeploymentProjects;
     private $insertDeploymentProject;
     private $deleteDeploymentProject;
 
     public function __construct(
+        AuthoriseDeploymentAccess $authoriseDeploymentAccess,
         FetchDeploymentProjects $fetchDeploymentProjects,
         InsertDeploymentProject $insertDeploymentProject,
         DeleteDeploymentProject $deleteDeploymentProject
     ) {
+        $this->authoriseDeploymentAccess = $authoriseDeploymentAccess;
         $this->fetchDeploymentProjects = $fetchDeploymentProjects;
         $this->insertDeploymentProject = $insertDeploymentProject;
         $this->deleteDeploymentProject = $deleteDeploymentProject;
@@ -24,7 +29,8 @@ class SetDeploymentProjects
 
     public function set(int $userId, int $deploymentId, array $newProjectsLayout)
     {
-        // TODO VALIDATE THE USER HAS ACCESS TO THE DEPLOYMENT
+        $this->authoriseDeploymentAccess->authorise($userId, $deploymentId);
+
         $currentProjects = $this->fetchDeploymentProjects->fetchAll($deploymentId);
         $currentProjects = $this->groupProjects($currentProjects);
 
@@ -49,6 +55,7 @@ class SetDeploymentProjects
         // Any projects left over should be removed
         foreach ($currentProjects as $hostId => $projects) {
             foreach ($projects as $project) {
+                //TODO Dont remove project if the user cant see it
                 $this->deleteDeploymentProject->delete($project["id"]);
             }
         }

--- a/src/classes/Tools/Deployments/Projects/SetDeploymentProjects.php
+++ b/src/classes/Tools/Deployments/Projects/SetDeploymentProjects.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace dhope0000\LXDClient\Tools\Deployments\Projects;
+
+use dhope0000\LXDClient\Model\Deployments\Projects\FetchDeploymentProjects;
+use dhope0000\LXDClient\Model\Deployments\Projects\InsertDeploymentProject;
+use dhope0000\LXDClient\Model\Deployments\Projects\DeleteDeploymentProject;
+
+class SetDeploymentProjects
+{
+    private $fetchDeploymentProjects;
+    private $insertDeploymentProject;
+    private $deleteDeploymentProject;
+
+    public function __construct(
+        FetchDeploymentProjects $fetchDeploymentProjects,
+        InsertDeploymentProject $insertDeploymentProject,
+        DeleteDeploymentProject $deleteDeploymentProject
+    ) {
+        $this->fetchDeploymentProjects = $fetchDeploymentProjects;
+        $this->insertDeploymentProject = $insertDeploymentProject;
+        $this->deleteDeploymentProject = $deleteDeploymentProject;
+    }
+
+    public function set(int $userId, int $deploymentId, array $newProjectsLayout)
+    {
+        // TODO VALIDATE THE USER HAS ACCESS TO THE DEPLOYMENT
+        $currentProjects = $this->fetchDeploymentProjects->fetchAll($deploymentId);
+        $currentProjects = $this->groupProjects($currentProjects);
+
+        foreach ($newProjectsLayout as $project) {
+            // TODO VALIDATE USER HAS ACCESS TO PROJECT
+
+            if (isset($currentProjects[$project["hostId"]])) {
+                if (isset($currentProjects[$project["hostId"]][$project["project"]])) {
+                    unset($currentProjects[$project["hostId"]][$project["project"]]);
+                    continue;
+                }
+            }
+
+            $this->insertDeploymentProject->insert(
+                $userId,
+                $deploymentId,
+                $project["hostId"],
+                $project["project"]
+            );
+        }
+
+        // Any projects left over should be removed
+        foreach ($currentProjects as $hostId => $projects) {
+            foreach ($projects as $project) {
+                $this->deleteDeploymentProject->delete($project["id"]);
+            }
+        }
+    }
+
+    private function groupProjects(array $currentProjects)
+    {
+        $output = [];
+        foreach ($currentProjects as $project) {
+            if (!isset($output[$project["hostId"]])) {
+                $output[$project["hostId"]] = [];
+            }
+            $output[$project["hostId"]][$project["project"]] = $project;
+        }
+        return $output;
+    }
+}

--- a/src/classes/Tools/User/ValidatePermissions.php
+++ b/src/classes/Tools/User/ValidatePermissions.php
@@ -40,6 +40,26 @@ class ValidatePermissions
         return true;
     }
 
+    public function canAccessHostProject(int $userId, int $hostId, string $project) :bool
+    {
+        $isAdmin = $this->isAdmin($userId);
+        if ($isAdmin) {
+            return true;
+        }
+
+        $allowedProjects = $this->fetchAllowedProjects->fetchForHost($userId, $hostId);
+
+        if (empty($allowedProjects)) {
+            return false;
+        }
+
+        if (!in_array($project, $allowedProjects)) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function isAdminOrThrow(int $userId) :bool
     {
         if (!$this->isAdmin($userId)) {

--- a/src/views/boxes/deployments.php
+++ b/src/views/boxes/deployments.php
@@ -75,7 +75,7 @@
         </div> -->
         <div class="row">
             <div class="col-md-3">
-                  <div class="card bg-dark text-white">
+                  <div class="card bg-dark text-white mb-2">
                     <div class="card-header" role="tab" id="deploymentCloudConfigHeading">
                       <h5>
                         <a class="text-white" data-bs-toggle="collapse" data-parent="#accordion" href="#deploymentCloudConfig" aria-expanded="true" aria-controls="deploymentCloudConfig">
@@ -89,6 +89,29 @@
                               <thead>
                                   <tr>
                                       <th> Cloud Config </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                              </tbody>
+                          </table>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="card bg-dark text-white">
+                    <div class="card-header" role="tab" id="deploymentProjectHeading">
+                      <h5>
+                        <a class="text-white" data-bs-toggle="collapse" data-parent="#accordion" href="#deploymentProjects" aria-expanded="true" aria-controls="deploymentProjects">
+                        Projects
+                        </a>
+                      </h5>
+                    </div>
+                    <div id="deploymentProjects" class="collapse show" role="tabpanel" aria-labelledby="deploymentProjectHeading">
+                      <div class="card-block bg-dark table-responsive">
+                          <table class="table table-bordered table-dark" id="deploymentProjectTable">
+                              <thead>
+                                  <tr>
+                                      <th> Host </th>
+                                      <th> Project </th>
                                   </tr>
                               </thead>
                               <tbody>
@@ -286,7 +309,17 @@ function viewDeployment(deploymentId)
             });
         }
 
+        let projectTrs = "";
 
+        $.each(data.projects, (_, project)=>{
+            projectTrs += `<tr>
+                <td>${project.hostAlias}</td>
+                <td>${project.project}</td>
+            </tr>`
+        });
+
+
+        $("#deploymentProjectTable > tbody").empty().append(projectTrs);
         $("#deploymentCloudConfigTable > tbody").empty().append(trs);
         $("#deploymentContainersList > tbody").empty().append(c);
         router.updatePageLinks();

--- a/src/views/boxes/deployments.php
+++ b/src/views/boxes/deployments.php
@@ -98,15 +98,16 @@
                     </div>
                   </div>
                   <div class="card bg-dark text-white">
-                    <div class="card-header" role="tab" id="deploymentProjectHeading">
+                    <div class="card-header">
                       <h5>
-                        <a class="text-white" data-bs-toggle="collapse" data-parent="#accordion" href="#deploymentProjects" aria-expanded="true" aria-controls="deploymentProjects">
                         Projects
-                        </a>
+                        <button class="btn btn-outline-primary btn-sm float-end" id="editDeploymentProjects">
+                            <i class="fas fa-wrench"></i>
+                        </button>
                       </h5>
                     </div>
-                    <div id="deploymentProjects" class="collapse show" role="tabpanel" aria-labelledby="deploymentProjectHeading">
-                      <div class="card-block bg-dark table-responsive">
+                    <div class="card-body table-responsive">
+
                           <table class="table table-bordered table-dark" id="deploymentProjectTable">
                               <thead>
                                   <tr>
@@ -117,7 +118,6 @@
                               <tbody>
                               </tbody>
                           </table>
-                      </div>
                     </div>
                   </div>
             </div>
@@ -326,6 +326,27 @@ function viewDeployment(deploymentId)
     });
 }
 
+$("#deploymentsBox").on("click", "#editDeploymentProjects", function(){
+    deploymentProjectsObj.deploymentId = currentDeployment
+    deploymentProjectsObj.callback = function(){
+        ajaxRequest(globalUrls.deployments.projects.getAll, {deploymentId: deploymentProjectsObj.deploymentId}, (data)=>{
+            data = makeToastr(data)
+            let projectTrs = "";
+
+            $.each(data, (_, project)=>{
+                projectTrs += `<tr>
+                    <td>${project.hostAlias}</td>
+                    <td>${project.project}</td>
+                </tr>`
+            });
+
+
+            $("#deploymentProjectTable > tbody").empty().append(projectTrs);
+        });
+    }
+    $("#modal-deployments-projects").modal("show")
+});
+
 $("#deploymentsBox").on("click", "#startDeployment", function(){
     $.confirm({
         title: 'Start Deployment',
@@ -424,4 +445,5 @@ $("#deploymentsBox").on("click", "#deploy", function(){
 <?php
     require __DIR__ . "/../modals/deployments/createDeployment.php";
     require __DIR__ . "/../modals/deployments/deploy.php";
+    require __DIR__ . "/../modals/deployments/projects.php";
 ?>

--- a/src/views/index.php
+++ b/src/views/index.php
@@ -223,6 +223,10 @@ if ($haveServers->haveAny() !== true) {
                   createPool: "/api/Storage/CreatePoolController/create"
               },
               deployments: {
+                  projects: {
+                    getAll: '/api/Deployments/Projects/GetDeploymentProjectsController/get',
+                    set: '/api/Deployments/Projects/SetDeploymentProjectsController/set'
+                  },
                   create: "/api/Deployments/CreateController/create",
                   getAll: "/api/Deployments/GetController/getAll",
                   getDeployment: "/api/Deployments/GetDeploymentController/get",

--- a/src/views/modals/deployments/projects.php
+++ b/src/views/modals/deployments/projects.php
@@ -1,0 +1,99 @@
+<!-- Modal -->
+<div class="modal fade" id="modal-deployments-projects" tabindex="-1" aria-labelledby="exampleModalLongTitle" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Deployment Projects</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" style="max-height: 80vh; height: 80vh; padding-top: 1px; overflow: scroll;">
+                <div class="row">
+                    <div class="col-md-12 pt-3">
+                        <div id="availableToAssignProjects"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="update" class="btn btn-primary">
+                    Update
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    var deploymentProjectsObj = {
+        deploymentId: null,
+        callback: null
+    }
+
+    $("#modal-deployments-projects").on("shown.bs.modal", function() {
+        $("#deployCloudConfigTable > tbody").empty();
+        ajaxRequest(globalUrls.deployments.projects.getAll, {deploymentId: deploymentProjectsObj.deploymentId}, (currentProjectsData)=>{
+            currentProjectsData = makeToastr(currentProjectsData);
+            let currentProjectStruct = {}
+            $.each(currentProjectsData, (_, project)=>{
+                if(!currentProjectStruct.hasOwnProperty(project.hostAlias)){
+                    currentProjectStruct[project.hostAlias] = []
+                }
+                currentProjectStruct[project.hostAlias].push(project.project)
+            });
+            ajaxRequest(globalUrls.universe.getEntities, {entity: "projects"}, (data)=>{
+                data = makeToastr(data)
+                let availableToAssign = "";
+                $.each(data.standalone.members, (_, member)=>{
+                    if(member.hostOnline == "0"){
+                        return true;
+                    }
+                    availableToAssign += `<div><h4><i class="fas fa-server me-2"></i>${member.alias}</h4>`
+                    $.each(member.projects, (_, project)=>{
+                        let active = "secondary";
+                        if(currentProjectStruct.hasOwnProperty(member.alias) && currentProjectStruct[member.alias].includes(project)){
+                            active = "primary"
+                        }
+                        availableToAssign += `<span style="cursor: pointer" class="badge bg-${active} m-2 deploymentProjectBadge" data-host-id="${member.hostId}" data-project="${project}">
+                            <h5>
+                                <i class="fas fa-project-diagram me-2"></i>${project}
+                            </h5>
+                        </span>`
+                    });
+                    availableToAssign += `</div>`
+                });
+                $("#availableToAssignProjects").empty().append(availableToAssign);
+            });
+        })
+    });
+
+    $("#modal-deployments-projects").on("click", ".deploymentProjectBadge", function() {
+        if($(this).hasClass("bg-primary")){
+            $(this).removeClass("bg-primary")
+            $(this).addClass("bg-secondary")
+        }else{
+            $(this).removeClass("bg-secondary")
+            $(this).addClass("bg-primary")
+        }
+    });
+
+    $("#modal-deployments-projects").on("click", "#update", function() {
+        let newProjectsLayout = [];
+        let btn = $(this)
+        btn.attr("disabled", true);
+        $(".deploymentProjectBadge.bg-primary").each(function(){
+            let badge = $(this);
+            newProjectsLayout.push(badge.data())
+        });
+
+        let x = {deploymentId: deploymentProjectsObj.deploymentId, newProjectsLayout}
+        ajaxRequest(globalUrls.deployments.projects.set, x, (data)=>{
+            data = makeToastr(data)
+            if(data.state == "success"){
+                if(typeof deploymentProjectsObj.callback === "function"){
+                    deploymentProjectsObj.callback();
+                }
+                $("#modal-deployments-projects").modal("hide")
+            }
+
+            btn.attr("disabled", false);
+        });
+    });
+</script>


### PR DESCRIPTION
Instead of Deployments being a global object that everyone can see they are now linked to project access.

If user has access to one of the projects a deployment is assigned to, they have access to the deployment.

Includes updating all existing endpoints to authorise user access to deployment before performing the action.

The migration includes a statement to add all existing deployments the "default"  project on the first host it can find.

Fixes #466.